### PR TITLE
Improve the visualization R script

### DIFF
--- a/src/main/scala/loquats/phylogeneticTree.scala
+++ b/src/main/scala/loquats/phylogeneticTree.scala
@@ -77,10 +77,12 @@ case object visualizations {
             paste("tail -n +2 ", inputFile),
             # Sort by frequency
             "sort -t$$'\\t' -k3 -nr",
-            # Keep the N first lines
-            "head -n50",
-            # Output the information as FASTA
-            "awk '{print \\">\\"$$2\\"\\\\n\\"$$5;}'",
+            # Keep the N first lines (otherwise it's too crowded)
+            "head -n25",
+            # Choosing only CDR3 sequence and AA-sequence columns
+            "cut -f 5,6",
+            # Output the information as FASTA with Amino-acid seq-s as headers
+            "awk '{print \\">\\"$$2\\"\\\\n\\"$$1;}'",
             sep=" | "
           )
 

--- a/src/main/scala/loquats/phylogeneticTree.scala
+++ b/src/main/scala/loquats/phylogeneticTree.scala
@@ -59,7 +59,7 @@ case object visualizations {
         val client = RClient(serializeOutput = true)
         val inputPath = productiveClonotypesTSV.getCanonicalPath()
         val outputPath = output(data.viz.phylogeneticTree).getCanonicalPath()
-        client eval s"""
+        client eval raw"""
           # Load needed libraries
           library("msa")
           library("ape")
@@ -75,14 +75,11 @@ case object visualizations {
           command <- paste(
             # Remove the header from the TSV
             paste("tail -n +2 ", inputFile),
-            # Sort by frequency
-            "sort -t$$'\\t' -k3 -nr",
+            "sort -t$$'\t' -k3 -nr",
             # Keep the N first lines (otherwise it's too crowded)
             "head -n25",
-            # Choosing only CDR3 sequence and AA-sequence columns
-            "cut -f 5,6",
-            # Output the information as FASTA with Amino-acid seq-s as headers
-            "awk '{print \\">\\"$$2\\"\\\\n\\"$$1;}'",
+            # Output the information as FASTA with Amino-acid seq-s + rounded frequencies as headers
+            "awk -F'\t' '{ printf \">%s - %.2f\\n%s\\n\", $$6, $$4, $$5 }'",
             sep=" | "
           )
 


### PR DESCRIPTION
This addresses one problem that I encountered in https://github.com/era7bio/tcrbsilvia/issues/5 (regarding having spaces in columns of the TSV) and some improvements recommended by @rtobes (less elements and amino acid sequences instead of IDs). I don't know if all of this applies equally to the MIODx usage of this project, so you tell me.

* change to using only top-25 to make the visualization less crowded
* use different columns: nucleotide sequence & amino acid sequence (so
  that the chart will show amino acid seq-s instead of the
  representative seq-s IDs)
* use `cut` to choose columns of interest, because `awk` splits by any
  whitespace and it breaks if any column contains spaces

Here's how it looks after the change:

![output](https://user-images.githubusercontent.com/766656/36862513-4f85dd96-1d87-11e8-89ad-e651bb5f5541.png)
